### PR TITLE
blueprint: Use Infrastructure constructor

### DIFF
--- a/kibanaExample.js
+++ b/kibanaExample.js
@@ -1,15 +1,15 @@
-const { createDeployment, Machine } = require('kelda');
+const { Infrastructure, Machine } = require('kelda');
 const Elasticsearch = require('@kelda/elasticsearch').Elasticsearch;
 const Kibana = require('./kibana.js').Kibana;
 
 const clusterSize = 2;
 
-const deployment = createDeployment({});
 const baseMachine = new Machine({ provider: 'Amazon' });
-deployment.deploy(baseMachine.asMaster());
-deployment.deploy(baseMachine.asWorker().replicate(clusterSize));
+const infra = new Infrastructure(
+  baseMachine,
+  baseMachine.replicate(clusterSize));
 
 const es = new Elasticsearch(clusterSize);
-es.deploy(deployment);
+es.deploy(infra);
 const kib = new Kibana(es);
-kib.deploy(deployment);
+kib.deploy(infra);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "./kibana.js",
   "license": "MIT",
   "dependencies": {
-    "kelda": "0.x",
+    "kelda": ">=0.0.5 <1.0.0",
     "@kelda/elasticsearch": "kelda/elasticsearch"
   },
   "devDependencies": {


### PR DESCRIPTION
This commit replaces the deprecated `createDeployment` function with the
new `Infrastructure` constructor.