### PR TITLE
Add plugin support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/kibana/kibana-oss:6.0.1
+{{#plugins}}
+RUN kibana-plugin install {{{.}}}
+{{/plugins}}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ to. Replace the `<ELASTICSEARCH URL>` string in
 
 It may be necessary to may also be necessary to modify the `elasticsearchPort`
 constant if the Elasticsearch cluster does not listen on port `443`.
+
+## Kelda-Hosted Elasticsearch
+
+**Note** The Kelda Elasticsearch blueprint is not compatible with the version
+of Kibana deployed by this blueprint. The Kelda Elasticsearch blueprint boots
+version 2.4, which is incompatible with Kibana version 6.

--- a/README.md
+++ b/README.md
@@ -1,143 +1,15 @@
-# Elasticsearch and Kibana for Kelda.js
+# Kibana
 
-[main.js](main.js) contains an example deployment that boots an Elasticsearch
-cluster connected to Kibana, and makes the Kibana web interface publicly
-accessible.
+[kibanaExample.js](kibanaExample.js) contains an example deployment that starts
+the Kibana web interface connected to an Elasticsearch cluster. The
+Elasticsearch cluster can be deployed using a hosted solution such as Amazon
+Elasticsearch.
 
-[Elasticsearch](https://www.elastic.co/products/elasticsearch) is a
-"distributed, RESTful search and analytics engine".
+## Configuration
 
-[Kibana](https://www.elastic.co/products/kibana) "lets you visualize your
-Elasticsearch data".
+The Kibana blueprint requires the URL of the Elasticsearch instance to connect
+to. Replace the `<ELASTICSEARCH URL>` string in
+[kibanaExample.js](./kibanaExample.js) with the appropriate URL.
 
-## Booting The Deployment
-
-This guide assumes Kelda is installed on your machine. If you have not yet
-setup Kelda, please follow the instructions in our [getting started
-guide](../../docs/GettingStarted.md). Specifically, you need to have:
-- The Kelda binary installed
-- The Kelda daemon running
-- AWS credentials setup
-- `QUILT_PATH` configured
-
-To deploy the Elasticsearch and Kibana cluster, simply `kelda run main.js`.
-
-You can track the status of the deployment with `kelda ps`. Once the status of
-all containers is `Running`, we can begin interacting with our cluster.
-
-## Interacting With The Cluster
-
-Kelda's job is basically done at this point: the containers are up, and can
-communicate with each other over the network. If a container happens to die,
-Kelda will handle restarting it for you.
-
-However, we'll still walk through [elastic's
-example](https://www.elastic.co/guide/en/kibana/3.0/using-kibana-for-the-first-time.html)
-of analyzing Shakespeare's works to show off some of the tools that come with
-Kelda.
-
-### Seeding Elasticsearch
-
-Our current deployment doesn't allow public access to Elasticsearch, but we
-need to access it to seed it with data. To do so, modify [main.js](main.js) as
-follows:
-
-```
--var es = new Elasticsearch(clusterSize);
-+var es = new Elasticsearch(clusterSize).allowFromPublic();
-```
-
-Save your change, then `kelda run main.js` for the change to be deployed. The
-diff showed by `kelda run` should show that `elasticsearch` now accepts
-connections from `public`.
-
-```
-+ "From": "public",
-+ "To": "elasticsearch",
-+ "MinPort": 9200,
-+ "MaxPort": 9200
-```
-
-To get the public IP of an Elasticsearch container, run `kelda ps` and
-copy the `PUBLIC IP` of any of the Elasticsearch containers. It does not matter
-which Elasticsearch container is used -- interacting with any of them will
-propagate changes to the entire cluster.
-
-```
-% kelda ps
-MACHINE         ROLE      PROVIDER    REGION       SIZE         PUBLIC IP        STATUS
-404c03a697ed    Master    Amazon      us-west-1    m3.medium    54.183.170.32    connected
-17f5ccb2a7a6    Worker    Amazon      us-west-1    m3.medium    54.153.44.229    connected
-cde7c928f1eb    Worker    Amazon      us-west-1    m3.medium    52.53.172.21     connected
-
-CONTAINER       MACHINE         COMMAND                           LABELS           STATUS     CREATED           PUBLIC IP
-009d3a163255    17f5ccb2a7a6    elasticsearch:2.4 --transport.    elasticsearch    running    30 seconds ago    54.153.44.229:9200
-
-a9b80d0f3b71    cde7c928f1eb    kibana:4 --port 5601 --elastic    kibana           running    17 seconds ago    52.53.172.21:5601
-f693393369e9    cde7c928f1eb    elasticsearch:2.4 --transport.    elasticsearch    running    19 seconds ago    52.53.172.21:9200
-```
-
-As a sanity check, make sure the container responds.
-
-```
-% curl 54.153.44.229:9200
-{
-  "name" : "Johann Schmidt",
-  "cluster_name" : "elasticsearch",
-  "cluster_uuid" : "6uh_et8iR2GcFfHuFEr06A",
-  "version" : {
-    "number" : "2.4.4",
-    "build_hash" : "fcbb46dfd45562a9cf00c604b30849a6dec6b017",
-    "build_timestamp" : "2017-01-03T11:33:16Z",
-    "build_snapshot" : false,
-    "lucene_version" : "5.5.2"
-  },
-  "tagline" : "You Know, for Search"
-}
-```
-
-Now, create the index.
-
-```
-% curl -XPUT http://54.153.44.229:9200/shakespeare -d '
-{
- "mappings" : {
-  "_default_" : {
-   "properties" : {
-    "speaker" : {"type": "string", "index" : "not_analyzed" },
-    "play_name" : {"type": "string", "index" : "not_analyzed" },
-    "line_id" : { "type" : "integer" },
-    "speech_number" : { "type" : "integer" }
-   }
-  }
- }
-}
-';
-```
-
-And populate it.
-
-```
-curl https://www.elastic.co/guide/en/kibana/3.0/snippets/shakespeare.json | curl -XPUT 54.153.44.229:9200/_bulk --data-binary @-
-```
-
-### Using Kibana
-
-With data in Elasticsearch, we can now view it in Kibana. We can find the
-public IP of the Kibana container using `kelda ps` as before.
-
-Go to the address (`52.53.172.21:5601` for the above output) in your browser.
-Uncheck `Index contains time-based events`, set the index to be `shakes*`, and
-hit `Create`.
-
-We can now issue queries and create dashboards to analyze Shakespeare's works.
-For example, to find lines containing the words "friends", "Romans", or
-"countrymen", click `Discover` in the navbar, and search `friends, Romans,
-countrymen`.
-
-## Cleaning Up
-
-Once done with the cluster, don't forget to destroy it with `kelda stop`.
-
-## More Information
-For more information, see [Kelda](http://kelda.io).
+It may be necessary to may also be necessary to modify the `elasticsearchPort`
+constant if the Elasticsearch cluster does not listen on port `443`.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,160 @@ The Kibana blueprint requires the URL of the Elasticsearch instance to connect
 to. Replace the `<ELASTICSEARCH URL>` string in
 [kibanaExample.js](./kibanaExample.js) with the appropriate URL.
 
-It may be necessary to may also be necessary to modify the `elasticsearchPort`
-constant if the Elasticsearch cluster does not listen on port `443`.
+It may also be necessary to modify the `elasticsearchPort` constant if the
+Elasticsearch cluster does not listen on port `443`.
+
+## Running with Amazon-Hosted Elasticsearch
+
+This section will walk through deploying the Kibana blueprint against an
+Amazon-hosted Elasticsearch.
+
+### Set Up Kelda
+
+This guide assumes you've installed Kelda. See the Kelda
+[Quick Start](http://docs.kelda.io/#quick-start) for instructions.
+
+### Set Up Elasticsearch
+
+To boot the Elasticsearch cluster:
+1. Go to the [AWS Elasticsearch dashboard](https://console.aws.amazon.com/es/home?region=us-east-1).
+2. Click the "Create a new domain" button.
+3. Pick a name for your Elasticsearch domain. This example uses "kelda-test".
+4. Select 6.0 as the Elasticsearch version. The Kibana blueprint deploys the
+   6.0.1 version of Kibana, so the Elasticsearch version must also be 6.0.
+5. Click "Next".
+6. The default cluster configuration is fine, so click "Next" to go to the
+   access configuration page.
+7. Set up the Network Configuration to allow "Public access"
+8. Set the domain access policy to "Allow open access to the domain". This
+   setting should not be used for production deployments. More fine-grained
+   access policies can be configured if Kibana is [deployed with a floating
+   IP](http://docs.kelda.io/#how-to-give-your-application-a-custom-domain-name).
+9. Click "Confirm" to create the Elasticsearch domain. The "Domain status" will
+   be loading for about 10 minutes, after which the Elasticsearch domain will
+   be able to be used with Kibana.
+
+### Boot Kibana
+
+The Elasticsearch domain must have finished initializing before Kibana can be
+booted. Once the domain is initialized, its URL should be available in the
+Amazon Elasticsearch dashboard under the "Endpoint" field.
+
+1. Open [kibanaExample](kibanaExample.js), and modify the
+   `elasticsearchURL` constant to be the Elasticsearch URL. For us, the
+   URL was https://search-kelda-test-zghtwerana5jgig5qvzhpfr7cm.us-east-1.es.amazonaws.com
+   -- your URL will be slightly different.
+2. Run `npm install .` to install the blueprint dependencies.
+3. Run `kelda run ./kibanaExample.js` to deploy the blueprint.
+4. Once `kelda show` shows the Kibana container as running, copy its address
+   from the `PUBLIC IP` column, and go to it in the browser.
+
+The Kibana management page should load. If a "Status: Red" page loads instead,
+then the Elasticsearch URL is most likely not properly configured.
+
+### Boot Kibana with a Plugin
+
+Kibana plugins can be installed by modifying the `kibanaExample.js` blueprint:
+
+1. Modify the `plugins` constant in [kibanaExample.js](kibanaExample.js) to
+   include the desired plugin. For example,
+```
+const plugins = [
+  'https://github.com/kklin/kbn_dotplot/releases/download/6.0.1/kbn_dotplot.zip',
+];
+```
+2. Run `kelda run ./kibanaExample.js` again.
+3. Wait until `kelda show` shows the Kibana container as running, and navigate
+   to the container's public IP as before. It is expected for the container to
+   be in the "building" state for a couple minutes while the plugins are
+   downloaded and installed.
+
+#### Kibana Plugin Limitations
+
+Because the Kibana plugin API is not yet stable, many Kibana plugins do not
+have releases for the version of Kibana deployed by the blueprint (6.0.1).
+
+Plugin repositories often have their own instructions on how to build their plugin for different versions of Kibana, but the overall process is usually the same:
+1. Download the plugin source.
+2. Modify the plugin's `package.json` to be the targeted Kibana version (6.0.1).
+3. Create a zip archive with `kibana` as the root folder, and the plugin source as a directory. For example, the directory structure of the `kbn_dotplot` archive is:
+```
+└── kibana
+    └── kbn_dotplot
+        ├── README.md
+        ├── package.json
+        ├── index.js
+        ... Other files required by the plugin
+```
+4. Upload the zip archive to a publicly accessible location.
+
+### Try Out Kibana
+
+This section is a quick introduction to using Kibana. It will place data into
+Elasticsearch, and visualize it with the dotplot plugin installed in [Boot
+Kibana with a Plugin](#boot-kibana-with-a-plugin).
+
+#### Seed Elasticsearch with Data
+
+This section will place some test bank account data into Elasticsearch.
+
+Run the following commands in a terminal. Replace `<Elasticsearch URL>` with
+the same URL used in the [Boot Kibana](#boot-kibana) section.
+
+```
+$ ELASTICSEARCH_URL=<Elasticsearch URL>
+
+# Create a temporary directory to download the data.
+$ workdir=$(mktemp -d)
+$ cd ${workdir}
+
+# Download the data.
+$ curl -O -L https://download.elastic.co/demos/kibana/gettingstarted/accounts.zip
+$ unzip accounts.zip
+
+# Upload it to Elasticsearch.
+$ curl -H 'Content-Type: application/x-ndjson' -XPOST "${ELASTICSEARCH_URL}/bank/account/_bulk?pretty" --data-binary @accounts.json
+
+# Remove the temporary directory.
+$ cd -
+$ rm -rf ${workdir}
+```
+
+#### Configure Kibana to Read the Data
+
+Once the example data is uploaded to Elasticsearch, Kibana must be configured
+to load it.
+
+1. Go to the Kibana management page. The container's public IP (e.g.
+   http://52.53.171.159:5601/) should redirect there automatically.
+2. Set the "Index pattern" to `bank*`.
+3. Click "Create".
+
+Going to the "Discover" page should now show the bank account information. This information can be filtered in the Search bar with queries such as `balance:>47500`.
+
+#### Visualizing the Data with DotPlot
+
+This section will demonstrate visualizing the bank account information with the
+[DotPlot](https://github.com/dlumbrer/kbn_dotplot) plugin. Using this plugin
+requires modifying and deploying the Kibana blueprint as described in [Boot
+Kibana with a Plugin](#boot-kibana-with-a-plugin).
+
+1. Go to the "Visualize" page.
+2. Click "Create a visualization".
+3. Click "Dot plot" under "Basic Charts".
+4. Select the `bank*` index.
+5. Under "Metrics" click "X-Axis", choose "Average" as the Aggregation, and
+   "age" as the Field.
+6. Click "Add metrics", click "Y-Axis", choose "Average" as the Aggregation,
+   and "balance" as the Field.
+7. Under "Buckets" click "Field", choose "Terms" as the Aggregation, and "age"
+   as the Field.
+8. Click the triangle at the top right of the pane to run the visualization. A
+   diagram should appear to the right that shows a plot of owner age to account
+   balance.
 
 ## Kelda-Hosted Elasticsearch
 
-**Note** The Kelda Elasticsearch blueprint is not compatible with the version
+**Note:** The Kelda Elasticsearch blueprint is not compatible with the version
 of Kibana deployed by this blueprint. The Kelda Elasticsearch blueprint boots
 version 2.4, which is incompatible with Kibana version 6.

--- a/kibana.js
+++ b/kibana.js
@@ -1,17 +1,23 @@
-const { Container, publicInternet, allowTraffic } = require('kelda');
+const kelda = require('kelda');
+const Mustache = require('mustache');
+const path = require('path');
+const fs = require('fs');
 
-const image = 'docker.elastic.co/kibana/kibana-oss:6.0.1';
 const port = 5601;
+const dockerfilePath = path.join(__dirname, 'Dockerfile');
+const dockerfileTemplate = fs.readFileSync(dockerfilePath, { encoding: 'utf8' });
 
-class Kibana extends Container {
-  constructor(esURL) {
+class Kibana extends kelda.Container {
+  constructor(esURL, plugins = []) {
+    const dockerfile = Mustache.render(dockerfileTemplate, { plugins });
+    const image = new kelda.Image('kelda-kibana', dockerfile);
     super('kibana', image, {
       env: {
         SERVER_PORT: port.toString(),
         ELASTICSEARCH_URL: esURL,
       },
     });
-    allowTraffic(publicInternet, this, port);
+    kelda.allowTraffic(kelda.publicInternet, this, port);
   }
 }
 

--- a/kibana.js
+++ b/kibana.js
@@ -1,20 +1,17 @@
 const { Container, publicInternet, allowTraffic } = require('kelda');
 
-function Kibana(es) {
-  this.container = new Container('kibana', 'kibana:4', {
-    command: [
-      '--port', this.port.toString(),
-      '--elasticsearch', es.uri(),
-    ],
-  });
-  es.addClient(this.container);
-  allowTraffic(publicInternet, this.container, this.port);
+const port = 5601;
+
+class Kibana extends Container {
+  constructor(esURL) {
+    super('kibana', 'kibana:4', {
+      command: [
+        '--port', port.toString(),
+        '--elasticsearch', esURL,
+      ],
+    });
+    allowTraffic(publicInternet, this, port);
+  }
 }
-
-Kibana.prototype.deploy = function deploy(depl) {
-  this.container.deploy(depl);
-};
-
-Kibana.prototype.port = 5601;
 
 exports.Kibana = Kibana;

--- a/kibana.js
+++ b/kibana.js
@@ -1,14 +1,15 @@
 const { Container, publicInternet, allowTraffic } = require('kelda');
 
+const image = 'docker.elastic.co/kibana/kibana-oss:6.0.1';
 const port = 5601;
 
 class Kibana extends Container {
   constructor(esURL) {
-    super('kibana', 'kibana:4', {
-      command: [
-        '--port', port.toString(),
-        '--elasticsearch', esURL,
-      ],
+    super('kibana', image, {
+      env: {
+        SERVER_PORT: port.toString(),
+        ELASTICSEARCH_URL: esURL,
+      },
     });
     allowTraffic(publicInternet, this, port);
   }

--- a/kibanaExample.js
+++ b/kibanaExample.js
@@ -8,6 +8,6 @@ const elasticsearchURL = '<ELASTICSEARCH URL>';
 const elasticsearchPort = 443;
 const elasticsearchURLWithPort = `${elasticsearchURL}:${elasticsearchPort}`;
 
-const kib = new Kibana(elasticsearchURLWithPort);
-kelda.allowTraffic(kib, kelda.publicInternet, elasticsearchPort);
-kib.deploy(infra);
+const kibana = new Kibana(elasticsearchURLWithPort);
+kelda.allowTraffic(kibana, kelda.publicInternet, elasticsearchPort);
+kibana.deploy(infra);

--- a/kibanaExample.js
+++ b/kibanaExample.js
@@ -11,5 +11,6 @@ const infra = new Infrastructure(
 
 const es = new Elasticsearch(clusterSize);
 es.deploy(infra);
-const kib = new Kibana(es);
+const kib = new Kibana(es.uri());
+es.addClient(kib);
 kib.deploy(infra);

--- a/kibanaExample.js
+++ b/kibanaExample.js
@@ -1,16 +1,13 @@
-const { Infrastructure, Machine } = require('kelda');
-const Elasticsearch = require('@kelda/elasticsearch').Elasticsearch;
+const kelda = require('kelda');
 const Kibana = require('./kibana.js').Kibana;
 
-const clusterSize = 2;
+const baseMachine = new kelda.Machine({ provider: 'Amazon' });
+const infra = new kelda.Infrastructure(baseMachine, baseMachine);
 
-const baseMachine = new Machine({ provider: 'Amazon' });
-const infra = new Infrastructure(
-  baseMachine,
-  baseMachine.replicate(clusterSize));
+const elasticsearchURL = '<ELASTICSEARCH URL>';
+const elasticsearchPort = 443;
+const elasticsearchURLWithPort = `${elasticsearchURL}:${elasticsearchPort}`;
 
-const es = new Elasticsearch(clusterSize);
-es.deploy(infra);
-const kib = new Kibana(es.uri());
-es.addClient(kib);
+const kib = new Kibana(elasticsearchURLWithPort);
+kelda.allowTraffic(kib, kelda.publicInternet, elasticsearchPort);
 kib.deploy(infra);

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "main": "./kibana.js",
   "license": "MIT",
   "dependencies": {
-    "kelda": ">=0.0.5 <1.0.0",
-    "@kelda/elasticsearch": "kelda/elasticsearch"
+    "kelda": ">=0.0.5 <1.0.0"
   },
   "devDependencies": {
     "eslint": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "./kibana.js",
   "license": "MIT",
   "dependencies": {
-    "kelda": ">=0.0.5 <1.0.0"
+    "kelda": ">=0.0.5 <1.0.0",
+    "mustache": "^2.3.0"
   },
   "devDependencies": {
     "eslint": "^4.3.0",


### PR DESCRIPTION
This PR upgrades Kibana to version 6 (which required removing the Kelda Elasticsearch library), and adds support for installing plugins.