### PR TITLE
blueprint: Use new constructor format

### DIFF
--- a/kibana.js
+++ b/kibana.js
@@ -10,8 +10,10 @@ const dockerfileTemplate = fs.readFileSync(dockerfilePath, { encoding: 'utf8' })
 class Kibana extends kelda.Container {
   constructor(esURL, plugins = []) {
     const dockerfile = Mustache.render(dockerfileTemplate, { plugins });
-    const image = new kelda.Image('kelda-kibana', dockerfile);
-    super('kibana', image, {
+    const image = new kelda.Image({ name: 'kelda-kibana', dockerfile });
+    super({
+      name: 'kibana',
+      image,
       env: {
         SERVER_PORT: port.toString(),
         ELASTICSEARCH_URL: esURL,

--- a/kibanaExample.js
+++ b/kibanaExample.js
@@ -5,7 +5,7 @@ const Kibana = require('./kibana.js').Kibana;
 // up the boot time. Installing a plugin on m3.large takes about 5 minutes,
 // while m3.medium takes about 10 minutes.
 const baseMachine = new kelda.Machine({ provider: 'Amazon', size: 'm3.large' });
-const infra = new kelda.Infrastructure(baseMachine, baseMachine);
+const infra = new kelda.Infrastructure({ masters: baseMachine, workers: baseMachine });
 
 const elasticsearchURL = '<ELASTICSEARCH URL>';
 const elasticsearchPort = 443;


### PR DESCRIPTION
The build will fail until the next release of Kelda (0.10.0). This should not be merged until then.